### PR TITLE
fix mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ td {
 
   /* Mobile */
    {
-    display: block;
+    display: table-cell;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,23 @@ function md(options) {
 
       // tbody rows
       if (index !== 0) {
+        node.children = node.children.map( (tableCell, i) => {
+          if(i !== 0){
+            return {
+              ...tableCell,
+              data: {
+                hProperties: {
+                  className: classDesktop
+                }
+              }
+            }
+          }else{
+            return {
+              ...tableCell
+            }
+          }
+        })
+
         node.children[0].children = [
           {
             type: "div",
@@ -44,23 +61,22 @@ function md(options) {
           },
           {
             type: "div",
-            children: [
-              {
-                type: "paragraph",
-                children: [
-                  ...node.children[0].children,
-                  {
-                    type: "paragraph",
-                    children: node.children[1].children,
-                    data: {
-                      hProperties: {
-                        className: classMobile
-                      }
-                    }
-                  }
-                ]
+            children: node.children.map( (tableCell, i) => {
+              const object = {
+                type: 'paragraph',
+                ...tableCell
               }
-            ],
+
+              if(i !== 0){
+                object.data = {
+                  hProperties: {
+                    className: classMobile
+                  }
+                }
+              }
+
+              return object
+            }),
             data: {
               hProperties: {
                 className: classnames.content
@@ -68,15 +84,6 @@ function md(options) {
             }
           }
         ];
-
-        node.children[1] = {
-          ...node.children[1],
-          data: {
-            hProperties: {
-              className: classDesktop
-            }
-          }
-        };
       }
     }
   };


### PR DESCRIPTION
there was a bug in the mobile layout. when columns of the table were more than 2, data of extra column cells was not copied into `content` div, and layout in mobile was broken.
![image](https://user-images.githubusercontent.com/38860648/97777733-62f9b900-1b87-11eb-865d-e51f900ca0e6.png)layout in descktop

![image](https://user-images.githubusercontent.com/38860648/97777754-87559580-1b87-11eb-83fd-6956634f7b32.png)layout in mobile

![image](https://user-images.githubusercontent.com/38860648/97777788-c7b51380-1b87-11eb-8256-608f388fc3cf.png)fixed layout in mobile

